### PR TITLE
fix: upgrade handlebars to address dependency vulnerability issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "handlebars": "1.3.x",
+    "handlebars": "4.0.0",
     "boom": "2.7.x",
     "hoek": "2.12.x",
     "joi": "6.1.x",


### PR DESCRIPTION
- handlebars v1.3.x uses a vulnerable version of uglify-js
- issue link: https://github.com/wycats/handlebars.js/pull/1084
